### PR TITLE
Fix check for inf2cat and signtool existence

### DIFF
--- a/patcher.ps1
+++ b/patcher.ps1
@@ -108,12 +108,12 @@ foreach($path in $signtool_paths)
     }
 }
 
-if(-Not(Test-Path $inf2cat))
+if([String]::IsNullOrEmpty($inf2cat) -or -Not(Test-Path $inf2cat))
 {
     Write-Host "[!] Failure: Unable to locate inf2cat, see/edit script for expected paths"
     exit
 }
-if(-Not(Test-Path $signtool))
+if([String]::IsNullOrEmpty($signtool) -or -Not(Test-Path $signtool))
 {
     Write-Host "[!] Failure: Unable to locate signtool, see/edit script for expected paths"
     exit


### PR DESCRIPTION
Script fails when it doesn't find a match in $inf2cat_paths or $signtool_paths.  Test-Path fails when passed a null value and that failure does not translate to $false, so -not cannot make it $true.  If the first check on a null value is [String]::IsNullOrEmpty, Test-Path won't run and won't throw an error.